### PR TITLE
Fix Windows static file serving for Web Dashboard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,6 +14,7 @@ import hmac
 import importlib.util
 import json
 import logging
+import ntpath
 import os
 import secrets
 import subprocess
@@ -2299,6 +2300,10 @@ def mount_spa(application: FastAPI):
     async def serve_spa(full_path: str):
         file_path = WEB_DIST / full_path
         # Prevent path traversal via url-encoded sequences (%2e%2e/)
+        drive, tail = ntpath.splitdrive(full_path)
+        tail = tail.lstrip('\\/')
+        file_path = WEB_DIST / tail
+
         if (
             full_path
             and file_path.resolve().is_relative_to(WEB_DIST.resolve())
@@ -2729,7 +2734,9 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
         raise HTTPException(status_code=404, detail="Plugin not found")
 
     base = Path(plugin["_dir"])
-    target = (base / file_path).resolve()
+    drive, tail = ntpath.splitdrive(file_path)
+    tail = tail.lstrip('\\/')
+    target = (base / tail).resolve()
 
     if not target.is_relative_to(base.resolve()):
         raise HTTPException(status_code=403, detail="Path traversal blocked")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -345,6 +345,20 @@ class TestWebServerEndpoints:
         if resp.status_code == 200:
             assert "FastAPI" not in resp.text  # Should not serve the actual source
 
+    def test_windows_absolute_path_blocked(self):
+        """Verify Windows absolute path injection is treated as relative safely."""
+        resp = self.client.get("/C:/Windows/System32/cmd.exe")
+        assert resp.status_code in (200, 404)
+        if resp.status_code == 200:
+            assert "root:" not in resp.text
+
+    def test_windows_backslash_blocked(self):
+        """Verify Windows backslashes are sanitized properly."""
+        resp = self.client.get("/\\Windows\\System32\\cmd.exe")
+        assert resp.status_code in (200, 404)
+        if resp.status_code == 200:
+            assert "root:" not in resp.text
+
 
 # ---------------------------------------------------------------------------
 # _build_schema_from_config tests


### PR DESCRIPTION
This PR resolves an issue on Windows where the Web Dashboard assets (SPA files and plugin static files) fail to load properly. Because `pathlib.Path` treats paths with leading slashes or drive letters (e.g. `C:/...`) as absolute, simply using the division operator `WEB_DIST / full_path` bypasses the base directory entirely on Windows. This change sanitizes incoming paths to guarantee they remain relative.

---
*PR created automatically by Jules for task [16185619075669619660](https://jules.google.com/task/16185619075669619660) started by @ArtisticMusician*