### PR TITLE
docs: add Windows native support fixes summary

### DIFF
--- a/WINDOWS_FIXES_SUMMARY.md
+++ b/WINDOWS_FIXES_SUMMARY.md
@@ -1,0 +1,48 @@
+# Windows Fixes v2 Summary
+
+This document summarizes the changes introduced in the `windows-fixes-v2` branch compared to the baseline commit (up to `3d258097d`). These changes aim to fully bring native Windows support, stabilization, and hardening to Hermes Agent.
+
+## Summary of Commits
+Below are the core commits that form the native Windows support implementation:
+
+1. **`feat: port core Windows native support (platform layer + process registry + installer)`**
+   - Introduced the core platform layer abstractions (`agent/platform/`) for handling Windows-specific interactions (like daemon management, IPC, and process supervision).
+   - Major rewrite/refactoring of `scripts/install.ps1` to make the installer fully compatible with Windows.
+   - Refactored `tools/process_registry.py` to handle Windows process spawning, tracking, and graceful termination.
+
+2. **`feat: port Windows gateway daemon, platform fixes, and dashboard build support`**
+   - Huge refactoring across the `gateway/` and `hermes_cli/` directories (over 20,000 lines changed) to support the gateway daemon on Windows.
+   - Made widespread changes to various messaging platforms under `gateway/platforms/` (Discord, Telegram, Slack, etc.) to ensure they run smoothly without POSIX-specific assumptions.
+   - Added `package-lock.json` and dashboard build adjustments in `web/` to resolve web asset building on Windows.
+
+3. **`chore(windows): add release script`**
+   - Added packaging scripts (like `packaging/windows/build-windows-package.ps1` and configuration under `packaging/windows/winget/`) for generating proper Windows releases and WinGet manifests.
+
+4. **`feat: complete native Windows support hardening`**
+   - Fortified the terminal backend (`tools/environments/terminal_backends.py`), handling Windows-specific interactive console environments.
+   - Fixed pathing/compatibility issues (`hermes_cli/path_compat.py`, `tools/windows_compat.py`).
+   - Hardened `scripts/install.ps1` further, dropping BOMs, adding commit/tag pinning parameters, and securing git operations.
+
+5. **`Merge branch 'feat/native-windows-support-clean' into windows-fixes-v2`**
+   - A major integration commit that brought in documentation updates, GitHub Action workflows for CI/CD checks on Windows, and numerous minor fixes that stabilize the native Windows environment.
+
+6. **`test: improve Windows Sandbox smoke diagnostics`**
+   - Added tests and diagnostics specifically targeting the Windows Sandbox harness.
+   - Introduced scripts like `scripts/windows-sandbox-smoke.ps1` and `scripts/windows-sandbox-validate.ps1`.
+   - Updated existing test suites (`tests/tools/test_terminal_windows_native_contract.py`, `tests/scripts/test_windows_packaging.py`) to fully validate the Windows port.
+
+## Key Areas Affected
+
+### Installer & Packaging
+- Heavy modifications to `scripts/install.ps1` to streamline Windows installation.
+- New scripts for building MSIX/EXE packages and WinGet manifests.
+
+### Platform Abstraction
+- Creation of `agent/platform/` with modules for `daemon`, `ipc`, `file_locker`, and `process`. This eliminates reliance on POSIX-only APIs.
+
+### Gateway & Connectivity
+- Extensive refactor of `gateway/run.py` and `hermes_cli/gateway.py`.
+- Adaptation of all `gateway/platforms/*` to be platform-agnostic.
+
+### Testing
+- Comprehensive smoke tests and validation scripts using Windows Sandbox to ensure isolated, clean-room testing of the agent on Windows.


### PR DESCRIPTION
This commit adds a Markdown document summarizing the core changes that bring native Windows support, stabilization, and hardening to Hermes Agent. The summary details the key architectural and packaging adjustments that happened over 6 distinct commits on the `windows-fixes-v2` branch.

---
*PR created automatically by Jules for task [14688095776506061257](https://jules.google.com/task/14688095776506061257) started by @ArtisticMusician*